### PR TITLE
ci: automate semver releases with api compatibility validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ## Description
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
 
+> The title of this pull request must be a [Conventional Commit](https://www.conventionalcommits.org/) subject, e.g. `feat(zip): add streaming extraction`, because it becomes the commit subject on `main` and drives the released version.
+
 ## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  commit-messages:
+    permissions:
+      contents: read
+    name: Commit messages
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # The whole branch is validated, not just its head
+      - name: 'Set up JDK 21'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'gradle'
+      - name: Check commit messages and pull request title
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}  # Squash merges turn the title into the commit subject
+        run: ./gradlew checkCommitMessages -Pcommits.base="origin/$BASE_REF" -Ppr.title="$PR_TITLE" --no-daemon
+
   build-ubuntu-21:
     permissions:
       contents: read
@@ -103,6 +126,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: ./gradlew build --continue --no-daemon --scan
+
+  release:
+    name: Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build-ubuntu-21
+      - build-ubuntu-25
+      - build-other-os
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
 
   configure_sonar:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,77 @@
 name: Release
 on:
+  workflow_call:
+    inputs:
+      dry_run:
+        description: 'Only compute the release plan, do not tag or publish'
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
-      jdk_version:
-        description: 'JDK version'
-        required: true
-        default: 21
+      dry_run:
+        description: 'Only compute the release plan, do not tag or publish'
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v')}}
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: "Set up JDK ${{ github.event.inputs.jdk_version }}"
+          fetch-depth: 0  # The version is derived from the tags and the commits that followed them
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ github.event.inputs.jdk_version }}
+          java-version: 21
           distribution: 'temurin'
           cache: 'gradle'
+
+      - name: Compute the release plan
+        id: plan
+        run: |
+          ./gradlew writeSemverPlan --no-daemon
+          cat build/semver/plan.properties >> "$GITHUB_OUTPUT"
+          {
+            echo '### Release plan'
+            echo '```properties'
+            cat build/semver/plan.properties
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nothing to release
+        if: steps.plan.outputs.release != 'true'
+        run: echo "No commit since v${{ steps.plan.outputs.previousVersion }} asks for a release."
+
+      - name: Tag v${{ steps.plan.outputs.nextVersion }}
+        if: steps.plan.outputs.release == 'true' && !inputs.dry_run
+        env:
+          VERSION: ${{ steps.plan.outputs.nextVersion }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "refs/tags/v$VERSION"
+          # The version comes from the checked out ref, building on the branch would produce a snapshot
+          git checkout "refs/tags/v$VERSION"
+
       - name: Create a release
-        run: ./gradlew publish
+        if: steps.plan.outputs.release == 'true' && !inputs.dry_run
+        run: ./gradlew publish --no-daemon
+
       - name: Release to Maven Central
+        if: steps.plan.outputs.release == 'true' && !inputs.dry_run
         env:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -44,3 +89,4 @@ jobs:
           path: |
             build/jreleaser/trace.log
             build/jreleaser/output.properties
+          if-no-files-found: ignore

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -26,7 +26,64 @@ Please follow these steps to have your contribution considered by the maintainer
 
 1.  Follow all instructions in the pull request template
 2.  Follow the style guides
-3.  After you submit your pull request, verify that all status checks are passing
+3.  Use a Conventional Commit subject as the pull request title
+4.  After you submit your pull request, verify that all status checks are passing
+
+Because pull requests can be squash merged, the pull request title becomes the commit subject on `main`, so CI validates the title as well as every commit of the branch.
+
+== Commit Messages
+
+Compress4J releases on every merge to `main`, and the version is derived from the commit messages, so they have to follow https://www.conventionalcommits.org/[Conventional Commits]:
+
+[source]
+----
+<type>[(<scope>)][!]: <description>
+----
+
+Allowed types are `fix`, `feat`, `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style` and `test`.
+
+[cols="1,1,3"]
+|===
+|Commit |Version bump |Example
+
+|`feat`
+|minor
+|`feat(zip): add streaming extraction`
+
+|`fix`, `perf`
+|patch
+|`fix(tar): close the stream on failure`
+
+|`!` suffix or a `BREAKING CHANGE:` footer
+|major
+|`feat(api)!: drop ArchiveFormat`
+
+|any other type
+|none, no release
+|`docs: describe the release process`
+|===
+
+A `commit-msg` hook enforces this locally. It is installed by any Gradle invocation, so it is in place after the first `./gradlew build`. In an emergency it can be skipped with `git commit --no-verify`, but CI checks the same rules.
+
+=== Version Bumps Are Validated Against the API
+
+Declaring the wrong type is caught by the build: `checkApiCompatibility` compares the jars against the last released version on Maven Central with https://github.com/melix/japicmp-gradle-plugin[Japicmp] and fails when the API changed more than the commits declare.
+
+[source,bash]
+----
+./gradlew checkApiCompatibility        # part of ./gradlew check
+./gradlew semverPlan                   # prints the version the current commits ask for
+----
+
+The required bump is derived from the public and protected API:
+
+* a source *or* binary incompatible change requires a major bump - for example removing or renaming a member, reducing its visibility, making a class final, or adding an abstract method to a public class or interface;
+* new public or protected API, and newly deprecated API, require at least a minor bump;
+* anything else is a patch.
+
+Adding a `default` method to an interface keeps it source compatible and therefore only needs a minor bump.
+
+When the check fails it lists the offending members; the detailed reports are in `build/reports/japicmp`. Use `-Papi.baseline=<version>` to compare against a specific release instead of the latest tag.
 
 == Development Setup
 
@@ -55,6 +112,10 @@ To run the tests, execute:
 ----
 
 === Releasing
+
+Releases are automatic. Once a merge to `main` passes CI, the `Release` workflow derives the next version from the commits since the last tag, pushes the `v<version>` tag, publishes to Maven Central and creates the GitHub release with a changelog built from the commit types. Merges that only contain non releasing types, such as `chore` or `docs`, publish nothing.
+
+The workflow can also be started manually; it defaults to a dry run that only reports the version it would release.
 
 For instructions on how to perform a local deployment using JReleaser, please refer to link:docs/jreleaser-local-deployment.adoc[JReleaser Local Deployment].
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 @file:Suppress("UnstableApiUsage")
 
 import com.diffplug.spotless.FormatterFunc
+import io.github.compress4j.semver.CheckApiCompatibilityTask
+import me.champeau.gradle.japicmp.JapicmpTask
 import org.jreleaser.model.Active
 import java.io.Serializable
 
@@ -16,6 +18,7 @@ plugins {
     alias(libs.plugins.sonarqube)
     alias(libs.plugins.spotless)
     id("publishing-conventions")
+    id("semver-conventions")
 }
 
 val stagingDir: Provider<Directory> = layout.buildDirectory.dir("staging-deploy")
@@ -158,6 +161,53 @@ tasks.withType<Test>().configureEach {
     })
 }
 
+val apiBaselineVersion: String = providers.gradleProperty("api.baseline").orElse(semver.previousVersion).get()
+
+// A named configuration would resolve back to the project being built, a detached one honours the coordinates.
+fun baselineArtifacts(classifier: String?): FileCollection = when {
+    apiBaselineVersion.isEmpty() -> files()
+    else -> configurations.detachedConfiguration(
+        dependencies.create(
+            listOfNotNull("${project.group}", project.name, apiBaselineVersion, classifier).joinToString(":") + "@jar"
+        )
+    ).apply { isTransitive = false }
+}
+
+fun registerApiComparison(name: String, baseline: FileCollection, jarTask: TaskProvider<Jar>, classpath: FileCollection) =
+    tasks.register<JapicmpTask>(name) {
+        onlyIf { apiBaselineVersion.isNotEmpty() }
+        oldArchives.from(baseline)
+        newArchives.from(jarTask)
+        oldClasspath.from(classpath)
+        newClasspath.from(classpath)
+        accessModifier = "protected"
+        onlyModified = true
+        ignoreMissingClasses = true
+        xmlOutputFile = layout.buildDirectory.file("reports/japicmp/$name.xml")
+        htmlOutputFile = layout.buildDirectory.file("reports/japicmp/$name.html")
+    }
+
+val japicmpMain = registerApiComparison(
+    "japicmpMain",
+    baselineArtifacts(null),
+    tasks.jar,
+    sourceSets.main.get().compileClasspath
+)
+val japicmpXzSupport = registerApiComparison(
+    "japicmpXzSupport",
+    baselineArtifacts("xz-support"),
+    tasks.named<Jar>("xzSupportJar"),
+    xzSupport.compileClasspath
+)
+
+val checkApiCompatibility = tasks.register<CheckApiCompatibilityTask>("checkApiCompatibility") {
+    group = "verification"
+    description = "Fails when the API changes since the last release ask for a bigger version bump than the commits declare."
+    baselineVersion = apiBaselineVersion
+    declaredBump = semver.declaredBump
+    reports.from(japicmpMain.flatMap { it.xmlOutputFile }, japicmpXzSupport.flatMap { it.xmlOutputFile })
+}
+
 dependencyAnalysis {
     issues {
         all {
@@ -195,7 +245,13 @@ tasks.testCodeCoverageReport {
 }
 
 tasks.check {
-    dependsOn(tasks.buildHealth, tasks.spotlessCheck, integrationTest, tasks.testCodeCoverageReport)
+    dependsOn(
+        tasks.buildHealth,
+        tasks.spotlessCheck,
+        checkApiCompatibility,
+        integrationTest,
+        tasks.testCodeCoverageReport
+    )
 }
 
 sonar {
@@ -311,6 +367,16 @@ publishing {
 }
 
 configure<org.jreleaser.gradle.plugin.JReleaserExtension> {
+    release {
+        github {
+            skipTag = true // The release workflow creates and pushes the tag
+            changelog {
+                formatted = Active.ALWAYS
+                preset = "conventional-commits"
+                links = true
+            }
+        }
+    }
     signing {
         pgp {
             active = Active.ALWAYS

--- a/gradle/build-logic/build.gradle.kts
+++ b/gradle/build-logic/build.gradle.kts
@@ -10,7 +10,9 @@ repositories {
 dependencies {
     implementation(libs.plugins.build.health.asDependency())
     implementation(libs.plugins.foojay.resolver.convention.asDependency())
+    implementation(libs.plugins.git.hooks.asDependency())
     implementation(libs.plugins.gradle.develocity.asDependency())
+    implementation(libs.plugins.japicmp.asDependency())
     implementation(libs.plugins.jreleaser.asDependency())
 }
 

--- a/gradle/build-logic/src/main/kotlin/git-hooks.settings.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/git-hooks.settings.gradle.kts
@@ -1,0 +1,6 @@
+plugins { id("org.danilopianini.gradle-pre-commit-git-hooks") }
+
+gitHooks {
+    commitMsg { conventionalCommits { defaultTypes() } }
+    createHooks(true)
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/CheckApiCompatibilityTask.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/CheckApiCompatibilityTask.kt
@@ -1,0 +1,59 @@
+package io.github.compress4j.semver
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+private const val MAX_REPORTED_CHANGES = 25
+
+abstract class CheckApiCompatibilityTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val reports: ConfigurableFileCollection
+
+    @get:Input
+    abstract val baselineVersion: Property<String>
+
+    @get:Input
+    abstract val declaredBump: Property<SemverBump>
+
+    @TaskAction
+    fun check() {
+        if (baselineVersion.get().isEmpty()) {
+            logger.warn("No release tag reachable, skipping the API compatibility check")
+            return
+        }
+        val changes = reports.files.flatMap { JapicmpReport.changes(it) }
+        val requiredBump = SemverBump.highestOf(changes.map { it.requiredBump })
+        val declared = declaredBump.get()
+
+        logger.lifecycle(
+            "API changes against ${baselineVersion.get()} require a $requiredBump bump, commits declare $declared"
+        )
+        if (declared >= requiredBump) return
+
+        val offenders = changes.filter { it.requiredBump > declared }
+            .sortedByDescending { it.requiredBump }
+            .take(MAX_REPORTED_CHANGES)
+        throw GradleException(
+            """
+            |The public API changed more than the commit messages declare.
+            |Required bump : $requiredBump
+            |Declared bump : $declared
+            |
+            |${offenders.joinToString("\n|") { "  $it" }}
+            |
+            |Report: ${reports.files.joinToString(", ") { it.path.replace(".xml", ".html") }}
+            |
+            |${ConventionalCommits.explainConvention()}
+            """.trimMargin()
+        )
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/CheckCommitMessagesTask.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/CheckCommitMessagesTask.kt
@@ -1,0 +1,41 @@
+package io.github.compress4j.semver
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+
+abstract class CheckCommitMessagesTask : DefaultTask() {
+
+    @get:Input
+    abstract val gitHistory: Property<String>
+
+    /** Validated on top of the commits: squash merges turn the pull request title into the commit subject. */
+    @get:Optional
+    @get:Input
+    abstract val pullRequestTitle: Property<String>
+
+    @TaskAction
+    fun check() {
+        val commits = parseGitHistory(gitHistory.get()).commits
+        val invalid = ConventionalCommits.invalidSubjects(commits).map { "${it.hash.take(8)} ${it.subject}" }
+        val invalidTitle = pullRequestTitle.orNull
+            ?.takeIf { it.isNotBlank() && !ConventionalCommits.isValidSubject(it) }
+            ?.let { "pull request title: $it" }
+        val failures = invalid + listOfNotNull(invalidTitle)
+
+        if (failures.isEmpty()) {
+            logger.lifecycle("All ${commits.size} commit message(s) follow Conventional Commits")
+            return
+        }
+        throw GradleException(
+            failures.joinToString(
+                prefix = "Invalid commit message(s):\n  ",
+                separator = "\n  ",
+                postfix = "\n\n" + ConventionalCommits.explainConvention()
+            )
+        )
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/ConventionalCommits.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/ConventionalCommits.kt
@@ -1,0 +1,43 @@
+package io.github.compress4j.semver
+
+data class Commit(val hash: String, val subject: String, val body: String)
+
+data class GitHistory(val previousVersion: String?, val commits: List<Commit>)
+
+object ConventionalCommits {
+
+    /** Kept in sync with the types of the generated `commit-msg` hook (`conventionalCommits { defaultTypes() }`). */
+    val types =
+        listOf("fix", "feat", "build", "chore", "ci", "docs", "perf", "refactor", "revert", "style", "test")
+
+    private val subjectPattern =
+        Regex("^(${types.joinToString("|")})(\\([^()]+\\))?(!)?: \\S.*$")
+
+    private val breakingFooterPattern = Regex("^BREAKING[ -]CHANGE:", RegexOption.MULTILINE)
+
+    fun isValidSubject(subject: String): Boolean = subjectPattern.matches(subject.trim())
+
+    fun bumpOf(commit: Commit): SemverBump {
+        val match = subjectPattern.matchEntire(commit.subject.trim()) ?: return SemverBump.NONE
+        val breaking = match.groupValues[3] == "!" || breakingFooterPattern.containsMatchIn(commit.body)
+        return when {
+            breaking -> SemverBump.MAJOR
+            match.groupValues[1] == "feat" -> SemverBump.MINOR
+            match.groupValues[1] in setOf("fix", "perf") -> SemverBump.PATCH
+            else -> SemverBump.NONE
+        }
+    }
+
+    fun declaredBump(commits: List<Commit>): SemverBump = SemverBump.highestOf(commits.map(::bumpOf))
+
+    fun invalidSubjects(commits: List<Commit>): List<Commit> = commits.filterNot { isValidSubject(it.subject) }
+
+    fun explainConvention(): String =
+        """
+        |Commit subjects and pull request titles must follow Conventional Commits:
+        |    <type>[(<scope>)][!]: <description>
+        |Allowed types: ${types.joinToString(", ")}
+        |A '!' suffix or a 'BREAKING CHANGE:' footer marks a breaking change.
+        |Version impact: feat -> minor, fix/perf -> patch, '!'/BREAKING CHANGE -> major, anything else -> no release.
+        """.trimMargin()
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/GitHistoryValueSource.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/GitHistoryValueSource.kt
@@ -1,0 +1,67 @@
+package io.github.compress4j.semver
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+
+private const val RECORD_SEPARATOR = '\u001E'
+private const val FIELD_SEPARATOR = '\u001F'
+private const val LOG_FORMAT = "--format=%H%x1f%s%x1f%b%x1e"
+
+/**
+ * Emits the latest reachable `v*` tag on the first line, followed by the `git log` records of the commits that
+ * followed it (or that followed [Params.base], when set).
+ */
+abstract class GitHistoryValueSource : ValueSource<String, GitHistoryValueSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val projectDir: Property<File>
+        val base: Property<String>
+    }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val tag = previousReleaseTag()
+        val base = parameters.base.orNull?.takeIf { it.isNotBlank() } ?: tag.takeIf { it.isNotEmpty() }
+        val range = base?.let { listOf("$it..HEAD") } ?: emptyList()
+        return tag + "\n" + git(*(listOf("log", "--no-merges", LOG_FORMAT) + range).toTypedArray())
+    }
+
+    /** When the head itself is tagged the release it describes is the one being validated, not the baseline. */
+    private fun previousReleaseTag(): String {
+        val head = if (git("describe", "--tags", "--match", "v*", "--exact-match", "HEAD").isNotBlank()) "HEAD^" else "HEAD"
+        return git("describe", "--tags", "--match", "v*", "--abbrev=0", head).trim()
+    }
+
+    private fun git(vararg args: String): String {
+        val output = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            commandLine(listOf("git") + args)
+            workingDir = parameters.projectDir.get()
+            standardOutput = output
+            errorOutput = ByteArrayOutputStream()
+            isIgnoreExitValue = true
+        }
+        return if (result.exitValue == 0) output.toString(Charsets.UTF_8.name()) else ""
+    }
+}
+
+fun parseGitHistory(raw: String): GitHistory {
+    val tagAndLog = raw.split('\n', limit = 2)
+    val previousVersion = tagAndLog[0].trim().removePrefix("v").ifBlank { null }
+    val commits = tagAndLog.getOrElse(1) { "" }
+        .split(RECORD_SEPARATOR)
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { record ->
+            val fields = record.split(FIELD_SEPARATOR)
+            Commit(fields[0], fields.getOrElse(1) { "" }, fields.getOrElse(2) { "" })
+        }
+    return GitHistory(previousVersion, commits)
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/JapicmpReport.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/JapicmpReport.kt
@@ -1,0 +1,77 @@
+package io.github.compress4j.semver
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+data class ApiChange(val kind: String, val path: String, val reason: String, val requiredBump: SemverBump) {
+    override fun toString(): String = "$kind $path: $reason, requires ${requiredBump.name.lowercase()}"
+}
+
+object JapicmpReport {
+
+    private const val DEPRECATION = "ANNOTATION_DEPRECATED_ADDED"
+
+    /** Elements of a japicmp report that describe API members; their children only carry the details of a change. */
+    private val apiElements = setOf("class", "method", "constructor", "field", "superclass", "interface")
+
+    /** Reads a japicmp XML report and returns the API changes that ask for a version bump, most specific first. */
+    fun changes(report: File): List<ApiChange> {
+        if (!report.isFile) return emptyList()
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            isXIncludeAware = false
+            isExpandEntityReferences = false
+        }
+        val document = report.inputStream().use { factory.newDocumentBuilder().parse(it) }
+        return collect(document.documentElement, "").distinct()
+    }
+
+    private fun collect(element: Element, path: String): List<ApiChange> {
+        val ownPath = pathOf(element, path)
+        val fromChildren = element.childElements().flatMap { collect(it, ownPath) }
+        val own = changeOf(element, ownPath) ?: return fromChildren
+        return if (fromChildren.any { it.requiredBump >= own.requiredBump }) fromChildren else fromChildren + own
+    }
+
+    private fun changeOf(element: Element, path: String): ApiChange? {
+        if (element.tagName !in apiElements) return null
+        val status = element.getAttribute("changeStatus").ifEmpty { return null }.lowercase()
+        val incompatibilities = element.compatibilityChanges()
+        val details = incompatibilities.ifEmpty { listOf(status) }.joinToString(", ")
+        return when {
+            element.getAttribute("binaryCompatible") == "false" ->
+                ApiChange(element.tagName, path, "binary incompatible ($details)", SemverBump.MAJOR)
+            element.getAttribute("sourceCompatible") == "false" ->
+                ApiChange(element.tagName, path, "source incompatible ($details)", SemverBump.MAJOR)
+            status == "new" -> ApiChange(element.tagName, path, "new public API", SemverBump.MINOR)
+            incompatibilities.contains(DEPRECATION) -> ApiChange(element.tagName, path, "newly deprecated", SemverBump.MINOR)
+            status == "unchanged" -> null
+            else -> ApiChange(element.tagName, path, status, SemverBump.PATCH)
+        }
+    }
+
+    private fun pathOf(element: Element, parentPath: String): String {
+        val name = element.getAttribute("fullyQualifiedName").ifEmpty { element.getAttribute("name") }
+        return when {
+            name.isEmpty() -> parentPath
+            parentPath.isEmpty() -> name
+            else -> "$parentPath#$name"
+        }
+    }
+
+    private fun Element.compatibilityChanges(): List<String> = childElements()
+        .filter { it.tagName == "compatibilityChanges" }
+        .flatMap { it.childElements() }
+        .map { it.getAttribute("type") }
+        .filter { it.isNotEmpty() }
+
+    private fun Element.childElements(): List<Element> {
+        val children = childNodes
+        return (0 until children.length)
+            .map { children.item(it) }
+            .filter { it.nodeType == Node.ELEMENT_NODE }
+            .map { it as Element }
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverBump.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverBump.kt
@@ -1,0 +1,28 @@
+package io.github.compress4j.semver
+
+/** Ordered from smallest to largest: comparisons rely on the declaration order. */
+enum class SemverBump {
+    NONE,
+    PATCH,
+    MINOR,
+    MAJOR;
+
+    companion object {
+        fun highestOf(bumps: Iterable<SemverBump>): SemverBump = bumps.maxOrNull() ?: NONE
+    }
+}
+
+fun nextVersion(previousVersion: String, bump: SemverBump): String {
+    val core = previousVersion.substringBefore('-').substringBefore('+')
+    val parts = core.split('.')
+    require(parts.size == 3 && parts.all { it.toIntOrNull() != null }) {
+        "Cannot derive the next version from '$previousVersion': expected a <major>.<minor>.<patch> release version"
+    }
+    val (major, minor, patch) = parts.map { it.toInt() }
+    return when (bump) {
+        SemverBump.MAJOR -> "${major + 1}.0.0"
+        SemverBump.MINOR -> "$major.${minor + 1}.0"
+        SemverBump.PATCH -> "$major.$minor.${patch + 1}"
+        SemverBump.NONE -> core
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverExtension.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverExtension.kt
@@ -1,0 +1,12 @@
+package io.github.compress4j.semver
+
+import org.gradle.api.provider.Property
+
+abstract class SemverExtension {
+
+    /** Version of the latest reachable `v*` tag, or empty when the repository has no release tag yet. */
+    abstract val previousVersion: Property<String>
+
+    /** Highest bump declared by the conventional commits since [previousVersion]. */
+    abstract val declaredBump: Property<SemverBump>
+}

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverPlanTask.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverPlanTask.kt
@@ -1,0 +1,54 @@
+package io.github.compress4j.semver
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class SemverPlanTask : DefaultTask() {
+
+    @get:Input
+    abstract val gitHistory: Property<String>
+
+    @get:Optional
+    @get:OutputFile
+    abstract val planFile: RegularFileProperty
+
+    @TaskAction
+    fun plan() {
+        val history = parseGitHistory(gitHistory.get())
+        val bump = ConventionalCommits.declaredBump(history.commits)
+        val previousVersion = history.previousVersion
+        val next = nextVersion(previousVersion ?: "0.0.0", bump)
+        val release = bump != SemverBump.NONE
+
+        ConventionalCommits.invalidSubjects(history.commits).forEach {
+            logger.warn("Ignoring non conventional commit ${it.hash.take(8)}: ${it.subject}")
+        }
+
+        logger.lifecycle(
+            """
+            |Previous version : ${previousVersion ?: "none"}
+            |Commits          : ${history.commits.size}
+            |Declared bump    : $bump
+            |Next version     : $next
+            |Release          : $release
+            """.trimMargin()
+        )
+
+        if (planFile.isPresent) {
+            planFile.get().asFile.apply { parentFile.mkdirs() }.writeText(
+                """
+                |previousVersion=${previousVersion ?: ""}
+                |bump=${bump.name.lowercase()}
+                |nextVersion=$next
+                |release=$release
+                |
+                """.trimMargin()
+            )
+        }
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/semver-conventions.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/semver-conventions.gradle.kts
@@ -1,0 +1,43 @@
+import io.github.compress4j.semver.CheckCommitMessagesTask
+import io.github.compress4j.semver.ConventionalCommits
+import io.github.compress4j.semver.GitHistoryValueSource
+import io.github.compress4j.semver.SemverExtension
+import io.github.compress4j.semver.SemverPlanTask
+import io.github.compress4j.semver.parseGitHistory
+
+plugins { id("me.champeau.gradle.japicmp") }
+
+val semver = extensions.create<SemverExtension>("semver")
+
+fun gitHistory(base: String?) = providers.of(GitHistoryValueSource::class) {
+    parameters {
+        projectDir.set(layout.projectDirectory.asFile)
+        this.base.set(base.orEmpty())
+    }
+}
+
+val historySinceLastRelease = gitHistory(null).map { parseGitHistory(it) }
+
+semver.previousVersion.set(historySinceLastRelease.map { it.previousVersion.orEmpty() })
+semver.declaredBump.set(historySinceLastRelease.map { ConventionalCommits.declaredBump(it.commits) })
+
+tasks.register<SemverPlanTask>("semverPlan") {
+    group = "release"
+    description = "Prints the version the commits since the last release tag ask for."
+    gitHistory.set(gitHistory(null))
+    outputs.upToDateWhen { false }
+}
+
+tasks.register<SemverPlanTask>("writeSemverPlan") {
+    group = "release"
+    description = "Writes the release plan derived from the commits since the last release tag."
+    gitHistory.set(gitHistory(null))
+    planFile.set(layout.buildDirectory.file("semver/plan.properties"))
+}
+
+tasks.register<CheckCommitMessagesTask>("checkCommitMessages") {
+    group = "verification"
+    description = "Checks that commit messages follow Conventional Commits."
+    gitHistory.set(gitHistory(providers.gradleProperty("commits.base").orNull))
+    pullRequestTitle.set(providers.gradleProperty("pr.title"))
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,12 @@ asm = "9.10.1"
 assertJ = "3.27.7"
 build-health = "3.16.0"
 foojay = "1.0.0"
+git-hooks = "2.1.21"
 git-version = "6.4.4"
 gradle-develocity = "4.5.0"
 jackson-bom = "2.22.0"
 jakarta-annotation = "3.0.0"
+japicmp = "0.4.6"
 jreleaser = "1.25.0"
 junit-bom = "6.1.1"
 logback = "1.5.37"
@@ -43,8 +45,10 @@ mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = 
 [plugins]
 build-health = { id = "com.autonomousapps.build-health", version.ref = "build-health" }
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
+git-hooks = { id = "org.danilopianini.gradle-pre-commit-git-hooks", version.ref = "git-hooks" }
 git-version = { id = "me.qoomon.git-versioning", version.ref = "git-version" }
 gradle-develocity = { id = "com.gradle.develocity", version.ref = "gradle-develocity" }
+japicmp = { id = "me.champeau.gradle.japicmp", version.ref = "japicmp" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/renovate.json
+++ b/renovate.json
@@ -14,26 +14,58 @@
     "dependencies",
     "renovate"
   ],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   "packageRules": [
     {
-      "groupName": "Non-major dependency updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ]
-    },
-    {
+      "description": "The build tooling never reaches users, so its updates must not trigger a release",
       "matchManagers": [
         "github-actions",
         "gradle-wrapper"
       ],
-      "groupName": "gradle and github actions"
+      "groupName": "gradle and github actions",
+      "semanticCommitType": "chore"
     },
     {
       "matchDepTypes": [
         "plugin"
       ],
-      "groupName": "gradle and github actions"
+      "groupName": "gradle and github actions",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "Test and build only libraries are not part of the published artifacts",
+      "matchPackageNames": [
+        "ch.qos.logback:logback-classic",
+        "ch.qos.logback:logback-core",
+        "com.fasterxml.jackson:jackson-bom",
+        "com.fasterxml.jackson.core:jackson-annotations",
+        "com.fasterxml.jackson.core:jackson-core",
+        "com.fasterxml.jackson.core:jackson-databind",
+        "org.assertj:assertj-core",
+        "org.junit:junit-bom",
+        "org.junit.jupiter:junit-jupiter-api",
+        "org.junit.jupiter:junit-jupiter-params",
+        "org.mockito:mockito-core",
+        "org.mockito:mockito-junit-jupiter",
+        "org.ow2.asm:asm"
+      ],
+      "groupName": "build and test dependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "description": "Runtime libraries reach users, so their updates are released as a patch",
+      "matchPackageNames": [
+        "commons-io:commons-io",
+        "jakarta.annotation:jakarta.annotation-api",
+        "org.apache.commons:commons-compress",
+        "org.apache.commons:commons-lang3",
+        "org.slf4j:slf4j-api",
+        "org.tukaani:xz"
+      ],
+      "groupName": "runtime dependencies",
+      "semanticCommitType": "fix"
     }
   ]
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement { includeBuild("gradle/build-logic") { name = rootProject.name 
 
 plugins {
     id("build-health")
+    id("git-hooks")
     id("gradle-develocity")
     id("foojay-resolver-convention")
 }


### PR DESCRIPTION
## Description

fix #22 
releases are now cut automatically from Conventional Commits, and the declared version bump is validated against the actual API change.

**Intent — Conventional Commits**
- A `commit-msg` hook is installed by any Gradle invocation (`git-hooks` settings convention plugin), so bad subjects are rejected locally.
- New PR-only `commit-messages` CI job runs `checkCommitMessages`, validating every commit of the branch **and** the PR title (squash merges use `COMMIT_OR_PR_TITLE`, so the title becomes the subject on `main`).

**Validation — source and binary compatibility**
- `japicmpMain` / `japicmpXzSupport` compare both published artifacts against the last released version on Maven Central.
- `checkApiCompatibility` (wired into `check`) derives the required bump from the reports and fails when the commits declare less: source **or** binary incompatibility requires major, new public/protected API and new deprecations require at least minor, anything else is a patch. Failures name the offending members and point at the HTML report.
- Japicmp's built-in `semverOutputFile` is not used: it maps an added public method to *patch* and source-only breaks to *minor*, which satisfies neither rule. The XML report is parsed instead.

**Release**
- `release.yml` became a reusable workflow called by CI after all build jobs pass on `main`. It computes the plan, exits cleanly when no commit asks for a release, pushes `v<version>`, checks out the tag (the `gitVersioning` branch rule would otherwise produce a snapshot), publishes and runs JReleaser. Manual dispatch defaults to a dry run.
- JReleaser gained `skipTag` (the workflow owns tagging) and a `conventional-commits` changelog preset.
- Renovate switched to semantic commits with deterministic groups: runtime libraries become `fix(deps)` (patch release), tooling and test dependencies become `chore(deps)` (no release).

#### Version impact

| Commit | Bump |
| --- | --- |
| `feat` | minor |
| `fix`, `perf` | patch |
| `!` or `BREAKING CHANGE:` | major |
| anything else | no release |

#### Verification

- `./gradlew build` green; no new Gradle deprecation warnings.
- Hook rejects `git commit -m "bad message"`, accepts `feat: ...`.
- Gate exercised in a scratch clone: a binary break as `fix:` fails demanding major and passes as `fix!:` (4.0.0); a new public method as `fix:` fails demanding minor and passes as `feat:` (3.1.0); an abstract method added to a public interface requires major (binary compatible, source incompatible) while a `default` method requires only minor.
- At a release tag the baseline falls back to the previous tag, so tag builds do not try to resolve an artifact that is not on Maven Central yet. With no tags at all the check skips with a warning.
- `Release` workflow dry runs on real runners: [nothing to release](https://github.com/compress4j/compress4j/actions/runs/30446971597) and, from a throwaway branch with a synthetic `fix:` commit, [`release=true`/`nextVersion=3.0.1` with the tag and publish steps skipped](https://github.com/compress4j/compress4j/actions/runs/30447296076). No tag was created and nothing was published.
- The publish path itself (`publish` + `jreleaserFullRelease`) can only be exercised by a real release.

This PR uses a non-releasing type (`ci`), so merging it publishes nothing; the first `feat:`/`fix:` merged afterwards cuts the first automated release.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — build logic has no test harness; verified end to end as described above
- [x] New and existing unit tests pass locally with my changes
