### PR TITLE
chore: harden renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,57 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": [
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":configMigration",
+    ":separateMultipleMajorReleases"
+  ],
+  "baseBranchPatterns": [
     "main"
   ],
-  "branchPrefix": "renovate-",
-  "dependencyDashboard": false,
-  "extends": [
-    "config:base",
-    "config:semverAllMonthly",
-    ":automergeMinor"
+  "schedule": [
+    "before 5am on monday"
   ],
+  "automerge": false,
+  "dependencyDashboard": true,
   "labels": [
     "dependencies",
     "renovate"
   ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "minimumReleaseAge": "3 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "description": "Renovate's defaults already bypass 'schedule' and 'minimumReleaseAge' here, so a CVE fix is not held back to Monday",
+    "labels": [
+      "dependencies",
+      "renovate",
+      "security"
+    ]
+  },
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
   "packageRules": [
     {
+      "description": "config:recommended maps depType 'dependencies' to 'fix', which every version catalog library gets. Releasing must be opt-in, so reset everything to 'chore' before the rules below re-enable it.",
+      "matchPackageNames": [
+        "*"
+      ],
+      "semanticCommitType": "chore"
+    },
+    {
       "description": "The build tooling never reaches users, so its updates must not trigger a release",
       "matchManagers": [
         "github-actions",
         "gradle-wrapper"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
       ],
       "groupName": "gradle and github actions",
       "semanticCommitType": "chore"
@@ -31,31 +60,32 @@
       "matchDepTypes": [
         "plugin"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "gradle and github actions",
       "semanticCommitType": "chore"
     },
     {
       "description": "Test and build only libraries are not part of the published artifacts",
       "matchPackageNames": [
-        "ch.qos.logback:logback-classic",
-        "ch.qos.logback:logback-core",
-        "com.fasterxml.jackson:jackson-bom",
-        "com.fasterxml.jackson.core:jackson-annotations",
-        "com.fasterxml.jackson.core:jackson-core",
-        "com.fasterxml.jackson.core:jackson-databind",
-        "org.assertj:assertj-core",
-        "org.junit:junit-bom",
-        "org.junit.jupiter:junit-jupiter-api",
-        "org.junit.jupiter:junit-jupiter-params",
-        "org.mockito:mockito-core",
-        "org.mockito:mockito-junit-jupiter",
-        "org.ow2.asm:asm"
+        "/^ch\\.qos\\.logback:/",
+        "/^com\\.fasterxml\\.jackson(\\.core)?:/",
+        "/^org\\.assertj:/",
+        "/^org\\.junit(\\.jupiter|\\.platform)?:/",
+        "/^org\\.mockito:/",
+        "/^org\\.ow2\\.asm:/"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
       ],
       "groupName": "build and test dependencies",
       "semanticCommitType": "chore"
     },
     {
-      "description": "Runtime libraries reach users, so their updates are released as a patch",
+      "description": "Runtime libraries reach users, so their updates are released as a patch. Listed exactly, never by pattern: a stray match here publishes to Maven Central.",
       "matchPackageNames": [
         "commons-io:commons-io",
         "jakarta.annotation:jakarta.annotation-api",
@@ -64,8 +94,32 @@
         "org.slf4j:slf4j-api",
         "org.tukaani:xz"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "runtime dependencies",
       "semanticCommitType": "fix"
+    },
+    {
+      "description": "commons-compress, commons-io and jakarta.annotation-api are api() dependencies, so a major bump can break consumers without changing compress4j's own signatures, which is all japicmp compares. Merging publishes nothing; retitle to 'feat(deps)!: ...' if the public API breaks.",
+      "matchPackageNames": [
+        "commons-io:commons-io",
+        "jakarta.annotation:jakarta.annotation-api",
+        "org.apache.commons:commons-compress",
+        "org.apache.commons:commons-lang3",
+        "org.slf4j:slf4j-api",
+        "org.tukaani:xz"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommitType": "chore",
+      "labels": [
+        "dependencies",
+        "renovate",
+        "api-review"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Audit and rework of `renovate.json` following the release automation added in #169. Config validated clean with `renovate-config-validator` (including the `baseBranches` → `baseBranchPatterns` migration it flagged).

### Majors were being released as patches

`config:semverAllMonthly` expands to `group:all` + `schedule:monthly` + `:preserveSemverRanges` + `:maintainLockFilesWeekly`, and sets `separateMajorMinor: false`. That folded majors into the per-category groups #169 introduced, so a major bump of `commons-compress`, `commons-io` or `jakarta.annotation-api` — all `api()` dependencies — would have landed in the `runtime dependencies` group as `fix(deps)` and cut a patch release. It also meant `:automergeMinor` never fired whenever any dep in a group had a major available, which matches the history of Renovate PRs sitting for up to 23 days awaiting a manual merge.

Replaced with an explicit weekly schedule and `:separateMultipleMajorReleases`. The other halves of the preset (`:preserveSemverRanges`, lock file maintenance) were no-ops for a Gradle version catalog.

### Releasing is now opt-in

`config:recommended` includes `:semanticPrefixFixDepsChoreOthers`, whose packageRule maps `depType: dependencies` to `fix`. Version catalog `[libraries]` entries all receive that depType, and packageRules override top-level config, so the previous top-level `"semanticCommitType": "chore"` did not win — any library not named in the allowlist would have been committed as `fix(deps)` and published. A leading `matchPackageNames: ["*"] → chore` rule resets that, so only the explicit runtime rule re-enables `fix`.

Test and build-only dependencies moved to regex patterns so adding e.g. `junit-jupiter-engine` needs no config edit. Runtime dependencies stay listed exactly: a stray pattern match there publishes to Maven Central, so the asymmetry is deliberate.

### Majors of runtime dependencies need a human

`japicmpMain` compares compress4j's own signatures, so it cannot see a break introduced through an `api()` dependency. Majors of the six runtime dependencies are held at `chore` and labelled `api-review` — merging publishes nothing, and the PR is retitled to `feat(deps)!: ...` if the public API actually breaks.

### Other changes

- `config:base` → `config:recommended` (renamed in Renovate v36), plus `:configMigration` so future renames arrive as a PR rather than a silent warning.
- `helpers:pinGitHubActionDigests`. `release.yml` holds `GPG_SECRET_KEY` and the Sonatype credentials, and every workflow referenced mutable tags. `digest` and `pin` are added to the tooling group so the resulting churn stays grouped and stays `chore`.
- `"automerge": false` explicitly. Redundant against the default, but merging to `main` now publishes, so the intent is worth stating.
- `dependencyDashboard` back on, `osvVulnerabilityAlerts` enabled, security updates labelled. Renovate's `vulnerabilityAlerts` defaults already bypass `schedule` and `minimumReleaseAge`, so a CVE fix is not deferred to Monday.
- `minimumReleaseAge: "3 days"`, `prConcurrentLimit: 3`, `prHourlyLimit: 2`.
- Dropped `branchPrefix: "renovate-"` for the default `renovate/`, which makes `renovate/**` usable in rulesets. There are no open Renovate PRs, so nothing is orphaned.

### Follow-up outside this PR

GitHub Dependabot alerts must be enabled on the repository or `vulnerabilityAlerts` never fires. Expect one large first PR pinning the actions to SHAs, and a new dependency dashboard issue.

## Type of change
- [x] Other: dependency automation configuration, no production code affected

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
