### PR TITLE
ci: analyse fork pull requests on maintainer request

### DIFF
--- a/.github/workflows/sonar-fork.yml
+++ b/.github/workflows/sonar-fork.yml
@@ -58,6 +58,7 @@ jobs:
           repository: ${{ steps.pr.outputs.head_repo }}
           ref: ${{ steps.pr.outputs.head_sha }}  # Pinned to the reviewed commit so a later push cannot slip in
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false  # The fork's build scripts run below and could otherwise read the token from .git/config
 
       - name: 'Set up JDK 21'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/.github/workflows/sonar-fork.yml
+++ b/.github/workflows/sonar-fork.yml
@@ -1,0 +1,91 @@
+name: Sonar (fork PR)
+
+# Fork pull requests are never given SONAR_TOKEN, so ci.yml cannot analyse them. A maintainer comments `/sonar` once
+# they have reviewed the diff — including build.gradle.kts and gradle/build-logic, which this workflow executes with
+# the token in scope.
+on:
+  issue_comment:
+    types: [ created ]
+
+concurrency:
+  group: sonar-fork-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  acknowledge:
+    # The only thing standing between a fork and SONAR_TOKEN, so it gates the analysis job via `needs` rather than
+    # being repeated on it, where the two copies could drift apart.
+    if: >-
+      github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/sonar')
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    name: Acknowledge
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: React to the trigger comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" -f content=eyes
+
+  sonar:
+    name: Sonar (fork PR)
+    needs: acknowledge
+    permissions:
+      contents: read  # No write scopes: this job executes the fork's build scripts
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Resolve pull request head
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid,headRefName,baseRefName,headRepositoryOwner,headRepository \
+            --jq '"head_sha=\(.headRefOid)\nhead_ref=\(.headRefName)\nbase_ref=\(.baseRefName)\nhead_repo=\(.headRepositoryOwner.login)/\(.headRepository.name)"' \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Checkout the reviewed commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_sha }}  # Pinned to the reviewed commit so a later push cannot slip in
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: 'Set up JDK 21'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'gradle'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.sonar/cache
+          key: ubuntu-latest-jdk_21-sonar
+          restore-keys: ubuntu-latest-jdk_21-sonar
+
+      - name: Build
+        run: ./gradlew build --continue --no-daemon
+
+      - name: Sonar analysis
+        # The scanner cannot auto-detect the pull request from an issue_comment event, so the context is passed in.
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          ./gradlew sonar --no-daemon \
+            "-Dsonar.pullrequest.key=$PR_NUMBER" \
+            "-Dsonar.pullrequest.branch=$HEAD_REF" \
+            "-Dsonar.pullrequest.base=$BASE_REF" \
+            -Dsonar.pullrequest.provider=GitHub \
+            "-Dsonar.pullrequest.github.repository=$GITHUB_REPOSITORY"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 htmlReport/
 out/
 target/
+/.envrc


### PR DESCRIPTION
## Description
Fork pull requests are never given `SONAR_TOKEN`, so `ci.yml` skips the analysis step and a fork gets no Sonar feedback at all. This adds a maintainer-triggered path: comment `/sonar` on the pull request and the scan runs against the fork's head.

The gate is `author_association` (`OWNER`/`MEMBER`/`COLLABORATOR`), so a fork contributor cannot trigger it themselves. The checkout is pinned to the head SHA resolved at trigger time, so a push landing after review is not what gets analysed. The scanner cannot auto-detect a pull request from an `issue_comment` event, so `sonar.pullrequest.*` is passed explicitly.

The analysis job holds `contents: read` and nothing else; the `issues: write` needed for the acknowledgement reaction lives in a separate job that never touches fork code. That job is also the gate, reached via `needs`, so the condition exists in one place only.

#### Blocking before merge
`SONAR_TOKEN` is currently a **user** token reaching four SonarQube Cloud organizations (`austek`, `compress4j`, `swagger2markup`, `jobrunr`). This workflow executes fork-authored `build.gradle.kts` and `gradle/build-logic/**` with that token in scope. It needs replacing with a project analysis token scoped to `compress4j_compress4j` first.

#### Not yet verified
Whether SonarQube Cloud attributes the SARIF upload to `refs/pull/N/head` when the pull request context arrives from a non-`pull_request` event. That determines whether `/sonar` clears the ruleset's `code_scanning` requirement. The first real fork pull request will settle it.

#### Residual risk
The security model is that whoever types `/sonar` has read the build files. Nothing enforces that.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Not applicable: no tests or documentation changes — this is CI configuration. Validated by parsing the workflow, checking the gate expression, and running the head-resolution step against a real fork pull request (#104).
