### PR TITLE
ci: audit workflows with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,27 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Validate the checksum of gradle-wrapper.jar
         uses: gradle/actions/wrapper-validation@90ddb51e90a5fd9ba75f40cf85156b7b41bf76a3 # v6
+
+  audit-workflows:
+    permissions:
+      contents: read
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Audit workflows with zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          version: 1.28.0  # Pinned so a zizmor release adding audits cannot fail unrelated pull requests
+          advanced-security: false  # Findings surface as annotations and the job result, not as code scanning alerts
+          annotations: true
 
   commit-messages:
     permissions:
@@ -38,6 +57,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # The whole branch is validated, not just its head
+          persist-credentials: false
       - name: 'Set up JDK 21'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
@@ -63,6 +83,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       - name: 'Set up JDK 21'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -103,6 +124,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       - name: 'Set up JDK 25'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -138,6 +160,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       - name: 'Set up JDK ${{ matrix.java-version }}'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,30 @@
+rules:
+  # Caches created by a pull request are not readable from main, so a pull request cannot poison the cache that the
+  # release job restores. Every setup-java and actions/cache step trips this, so the whole file is ignored.
+  cache-poisoning:
+    ignore:
+      - ci.yml
+
+  # Worth fixing, but narrowing this means declaring each secret in release.yml's workflow_call block too, and a mistake
+  # there only surfaces during a real release. Left for a change that can be verified on its own.
+  secrets-inherit:
+    ignore:
+      - ci.yml
+
+  # The digests do resolve to the commented major tag; zizmor wants the exact patch version, and Renovate owns these
+  # pins.
+  ref-version-mismatch:
+    ignore:
+      - ci.yml
+      - release.yml
+      - sonar-fork.yml
+
+  # The release job pushes the version tag over these credentials.
+  artipacked:
+    ignore:
+      - release.yml
+
+  # previousVersion is produced by an earlier step in the same workflow, not by anything a contributor controls.
+  template-injection:
+    ignore:
+      - release.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -299,7 +299,7 @@ sonar {
         property("sonar.projectKey", "compress4j_compress4j")
         property("sonar.organization", "compress4j")
         property("sonar.host.url", "https://sonarcloud.io")
-        property("sonar.sources", "src/main/java,src/xzSupport/java,src/examples/java")
+        property("sonar.sources", "src/main/java,src/xzSupport/java,src/examples/java,.github/workflows")
         property("sonar.tests", "src/test/java,src/xzSupportTest/java,src/integrationTest/java,src/testFixtures/java")
         property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml")
         property(


### PR DESCRIPTION
## Description
Adds [zizmor](https://docs.zizmor.sh) as a CI job and brings `.github/workflows` into the Sonar analysis scope. Both audit the workflows themselves, which nothing covered before — `sonar.sources` was pinned to three Java directories, so Sonar never looked at them.

zizmor found a real issue on its first run: the fork analysis job added in #178 checked out the fork with credentials persisted in `.git/config`, then ran that fork's Gradle build scripts. Fixed on that branch. The remaining `persist-credentials: false` additions here close the same gap on the rest of `ci.yml`.

`.github/zizmor.yml` records the nine findings that are accepted rather than fixed, each with the reason. Two are worth revisiting separately:

- **`secrets-inherit`** — `ci.yml` passes `secrets: inherit` to `release.yml`. Narrowing it means declaring each secret in the called workflow's `workflow_call` block, and a mistake there only shows up during a real release, so it wants a change that can be verified on its own.
- **`cache-poisoning`** — accepted because caches created by a pull request are not readable from `main`, so a pull request cannot poison the cache the release job restores.

The zizmor version is pinned rather than `latest`, so a release adding new audits cannot fail unrelated pull requests. SARIF upload is off: findings surface as annotations and the job result, which keeps zizmor out of the ruleset's code scanning requirement and avoids needing `security-events: write`.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Verified by running zizmor 1.28.0 locally against every workflow: clean, exit 0, 9 ignored. Bringing workflows into `sonar.sources` may surface new Sonar findings, and the ruleset gates merges on code scanning alerts at `all`, so the first run wants watching.
