### PR TITLE
ci: publish the version the release plan asked for

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,31 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "refs/tags/v$VERSION"
-          # The version comes from the checked out ref, building on the branch would produce a snapshot
-          git checkout "refs/tags/v$VERSION"
+
+      # git-versioning reads GITHUB_REF on Actions, so checking the tag out does not change the version. Naming the tag
+      # is what makes the steps below build the release version instead of a snapshot of the branch they run on.
+      - name: Verify the version resolves to v${{ steps.plan.outputs.nextVersion }}
+        if: steps.plan.outputs.release == 'true' && !inputs.dry_run
+        env:
+          VERSION: ${{ steps.plan.outputs.nextVersion }}
+          VERSIONING_GIT_TAG: v${{ steps.plan.outputs.nextVersion }}
+        run: |
+          resolved=$(./gradlew --quiet properties --property version --no-daemon | awk '$1 == "version:" { print $2 }')
+          if [ "$resolved" != "$VERSION" ]; then
+            echo "::error::Gradle resolved the version as '$resolved', the release plan asked for '$VERSION'"
+            exit 1
+          fi
 
       - name: Create a release
         if: steps.plan.outputs.release == 'true' && !inputs.dry_run
+        env:
+          VERSIONING_GIT_TAG: v${{ steps.plan.outputs.nextVersion }}
         run: ./gradlew publish --no-daemon
 
       - name: Release to Maven Central
         if: steps.plan.outputs.release == 'true' && !inputs.dry_run
         env:
+          VERSIONING_GIT_TAG: v${{ steps.plan.outputs.nextVersion }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Description
The v3.1.0 release tagged and reported success but shipped nothing. `git-versioning` reads `GITHUB_REF` on GitHub Actions, so `git checkout "refs/tags/v$VERSION"` never changed the version the publish steps saw:

```
Note: switching to 'refs/tags/v3.1.0'.
gather git situation from GitHub Actions environment variable: GITHUB_REF
matching ref: BRANCH - main
project version: 3.1.1-SNAPSHOT
[WARN]  [validation] Deployer mavenCentral:sonatype is not enabled. Skipping
[INFO]  Release is snapshot
[INFO]  JReleaser succeeded after 2.895 s
```

Because the tag existed by then, `patch.next` pushed the version *up* to `3.1.1-SNAPSHOT`. JReleaser then disabled the Maven Central deployer (it does not support snapshots, overriding `Active.ALWAYS`), published the rolling `early-access` pre-release instead, and exited 0 — a green release that put nothing on Central.

Changes:
- Name the tag via `VERSIONING_GIT_TAG` on the publish and JReleaser steps, which is what the plugin documents for detached CI checkouts, and drop the `git checkout` that only appeared to do this.
- Add a step that fails the job when the resolved version does not match the planned one, so this class of silent no-op release cannot go green again.

Verified locally: `VERSIONING_GIT_TAG=v3.0.0 ./gradlew -q properties --property version` resolves `3.0.0`, and the guard fires when the planned version differs.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes