### PR TITLE
build: fall back to the newest published release for the API baseline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,18 +164,40 @@ tasks.withType<Test>().configureEach {
 val apiBaselineVersion: String = providers.gradleProperty("api.baseline").orElse(semver.previousVersion).get()
 
 // A named configuration would resolve back to the project being built, a detached one honours the coordinates.
-fun baselineArtifacts(classifier: String?): FileCollection = when {
-    apiBaselineVersion.isEmpty() -> files()
-    else -> configurations.detachedConfiguration(
-        dependencies.create(
-            listOfNotNull("${project.group}", project.name, apiBaselineVersion, classifier).joinToString(":") + "@jar"
-        )
-    ).apply { isTransitive = false }
+fun baselineConfiguration(version: String, classifier: String?): Configuration = configurations.detachedConfiguration(
+    dependencies.create(
+        listOfNotNull("${project.group}", project.name, version, classifier).joinToString(":") + "@jar"
+    )
+).apply { isTransitive = false }
+
+// A release can tag a version that never reached the repository, so the newest tag is not always downloadable.
+// Falling back to the newest one that is keeps the check running instead of failing every build until that release
+// is fixed.
+val publishedBaselineVersion: String by lazy {
+    val candidates = listOf(apiBaselineVersion).filter { it.isNotEmpty() }
+        .plus(semver.releaseVersions.get())
+        .distinct()
+    val published = candidates.firstOrNull {
+        baselineConfiguration(it, null).incoming.artifactView { lenient(true) }.artifacts.artifacts.isNotEmpty()
+    }
+    when {
+        published == null -> "".also {
+            logger.warn("None of the release tags $candidates is published, skipping the API compatibility check")
+        }
+        published != apiBaselineVersion -> published.also {
+            logger.warn("Release $apiBaselineVersion is tagged but not published, comparing the API against $it instead")
+        }
+        else -> published
+    }
 }
+
+fun baselineArtifacts(classifier: String?): FileCollection = files({
+    publishedBaselineVersion.takeIf { it.isNotEmpty() }?.let { baselineConfiguration(it, classifier) } ?: files()
+})
 
 fun registerApiComparison(name: String, baseline: FileCollection, jarTask: TaskProvider<Jar>, classpath: FileCollection) =
     tasks.register<JapicmpTask>(name) {
-        onlyIf { apiBaselineVersion.isNotEmpty() }
+        onlyIf { publishedBaselineVersion.isNotEmpty() }
         oldArchives.from(baseline)
         newArchives.from(jarTask)
         oldClasspath.from(classpath)
@@ -203,7 +225,7 @@ val japicmpXzSupport = registerApiComparison(
 val checkApiCompatibility = tasks.register<CheckApiCompatibilityTask>("checkApiCompatibility") {
     group = "verification"
     description = "Fails when the API changes since the last release ask for a bigger version bump than the commits declare."
-    baselineVersion = apiBaselineVersion
+    baselineVersion = provider { publishedBaselineVersion }
     declaredBump = semver.declaredBump
     reports.from(japicmpMain.flatMap { it.xmlOutputFile }, japicmpXzSupport.flatMap { it.xmlOutputFile })
 }

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/ReleaseTagsValueSource.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/ReleaseTagsValueSource.kt
@@ -1,0 +1,41 @@
+package io.github.compress4j.semver
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+
+/** Emits the reachable `v*` tags, newest first, one per line. */
+abstract class ReleaseTagsValueSource : ValueSource<String, ReleaseTagsValueSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val projectDir: Property<File>
+    }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val tags = git("tag", "--list", "v*", "--merged", "HEAD", "--sort=-v:refname")
+        val headTag = git("describe", "--tags", "--match", "v*", "--exact-match", "HEAD").trim()
+        return tags.lines().filter { it.trim() != headTag }.joinToString("\n")
+    }
+
+    private fun git(vararg args: String): String {
+        val output = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            commandLine(listOf("git") + args)
+            workingDir = parameters.projectDir.get()
+            standardOutput = output
+            errorOutput = ByteArrayOutputStream()
+            isIgnoreExitValue = true
+        }
+        return if (result.exitValue == 0) output.toString(Charsets.UTF_8.name()) else ""
+    }
+}
+
+fun parseReleaseTags(raw: String): List<String> =
+    raw.lines().map { it.trim().removePrefix("v") }.filter { it.isNotEmpty() }

--- a/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverExtension.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/compress4j/semver/SemverExtension.kt
@@ -1,11 +1,15 @@
 package io.github.compress4j.semver
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 abstract class SemverExtension {
 
     /** Version of the latest reachable `v*` tag, or empty when the repository has no release tag yet. */
     abstract val previousVersion: Property<String>
+
+    /** Versions of the reachable `v*` tags, newest first, excluding a tag on the head itself. */
+    abstract val releaseVersions: ListProperty<String>
 
     /** Highest bump declared by the conventional commits since [previousVersion]. */
     abstract val declaredBump: Property<SemverBump>

--- a/gradle/build-logic/src/main/kotlin/semver-conventions.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/semver-conventions.gradle.kts
@@ -1,9 +1,11 @@
 import io.github.compress4j.semver.CheckCommitMessagesTask
 import io.github.compress4j.semver.ConventionalCommits
 import io.github.compress4j.semver.GitHistoryValueSource
+import io.github.compress4j.semver.ReleaseTagsValueSource
 import io.github.compress4j.semver.SemverExtension
 import io.github.compress4j.semver.SemverPlanTask
 import io.github.compress4j.semver.parseGitHistory
+import io.github.compress4j.semver.parseReleaseTags
 
 plugins { id("me.champeau.gradle.japicmp") }
 
@@ -20,6 +22,11 @@ val historySinceLastRelease = gitHistory(null).map { parseGitHistory(it) }
 
 semver.previousVersion.set(historySinceLastRelease.map { it.previousVersion.orEmpty() })
 semver.declaredBump.set(historySinceLastRelease.map { ConventionalCommits.declaredBump(it.commits) })
+semver.releaseVersions.set(
+    providers.of(ReleaseTagsValueSource::class) {
+        parameters { projectDir.set(layout.projectDirectory.asFile) }
+    }.map { parseReleaseTags(it) }
+)
 
 tasks.register<SemverPlanTask>("semverPlan") {
     group = "release"

--- a/gradle/build-logic/src/test/kotlin/io/github/compress4j/semver/ReleaseTagsTest.kt
+++ b/gradle/build-logic/src/test/kotlin/io/github/compress4j/semver/ReleaseTagsTest.kt
@@ -1,0 +1,22 @@
+package io.github.compress4j.semver
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ReleaseTagsTest {
+
+    @Test
+    fun `strips the prefix and keeps the order git listed the tags in`() {
+        assertThat(parseReleaseTags("v3.1.0\nv3.0.0\nv2.2.1")).containsExactly("3.1.0", "3.0.0", "2.2.1")
+    }
+
+    @Test
+    fun `blank lines are dropped`() {
+        assertThat(parseReleaseTags("v1.0.0\n\n  \n")).containsExactly("1.0.0")
+    }
+
+    @Test
+    fun `no tag at all yields no candidates`() {
+        assertThat(parseReleaseTags("")).isEmpty()
+    }
+}


### PR DESCRIPTION
## Description
A release can push a version tag without the artifact reaching the repository, which is exactly what happened with v3.1.0 (see #181). `japicmp` then could not resolve the baseline and every build failed:

```
Execution failed for task ':japicmpMain'.
> Could not find io.github.compress4j:compress4j:3.1.0.
```

`main` itself stayed green only because `previousReleaseTag()` already falls back to `HEAD^` when the head is the tagged commit, so the breakage showed up on every pull request instead.

The baseline now walks the reachable `v*` tags newest first and compares against the first one that actually resolves, reporting the substitution:

```
Release 3.1.0 is tagged but not published, comparing the API against 3.0.0 instead
```

This is a safety net, not a substitute for a correct release — `declaredBump` is derived from the same tags, so an unpublished tag can still make the required and declared bumps disagree. #181 fixes the cause.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes